### PR TITLE
update offsetMap

### DIFF
--- a/goid.go
+++ b/goid.go
@@ -30,6 +30,7 @@ func init() {
 		"go1.11.2": 152,
 		"go1.12.7": 152,
 		"go1.13.7": 152,
+		"go1.14":   152,
 	}
 
 	version := runtime.Version()


### PR DESCRIPTION
go1.14 runtime2.go 文件中表明，goid的offset为152。